### PR TITLE
Mark playlist types sendable

### DIFF
--- a/Sources/M3U8Decoder/MasterPlaylist.swift
+++ b/Sources/M3U8Decoder/MasterPlaylist.swift
@@ -29,7 +29,7 @@ import Foundation
 ///     #EXT-X-SESSION-DATA:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.4
-public struct EXT_X_SESSION_DATA: Decodable {
+public struct EXT_X_SESSION_DATA: Decodable, Sendable {
   /// The value of DATA-ID is a quoted-string that identifies a particular data value. This attribute is REQUIRED.
   public let data_id: String
   /// VALUE is a quoted-string.  It contains the data identified by DATA-ID. This attribute is REQUIRED.
@@ -45,7 +45,7 @@ public struct EXT_X_SESSION_DATA: Decodable {
 ///     #EXT-X-START:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.5.2
-public struct EXT_X_START: Decodable {
+public struct EXT_X_START: Decodable, Sendable {
   /// The value of TIME-OFFSET is a signed-decimal-floating-point number of seconds. This attribute is REQUIRED.
   public let time_offset: Int
   /// The value is an enumerated-string; valid strings are YES and NO. This attribute is OPTIONAL.
@@ -57,7 +57,7 @@ public struct EXT_X_START: Decodable {
 ///     #EXT-X-MEDIA:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1
-public struct EXT_X_MEDIA: Decodable {
+public struct EXT_X_MEDIA: Decodable, Sendable {
   /// The value is an enumerated-string; valid strings are AUDIO, VIDEO, SUBTITLES, and CLOSED-CAPTIONS. This attribute is REQUIRED.
   public let type: String
   /// The value is a quoted-string that specifies the group to which the Rendition belongs. This attribute is REQUIRED.
@@ -89,7 +89,7 @@ public struct EXT_X_MEDIA: Decodable {
 ///     RESOLUTION=<width>x<height>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.2
-public struct RESOLUTION: Decodable {
+public struct RESOLUTION: Decodable, Sendable {
   /// Width of a video.
   public let width: Int
   /// Height of a video.
@@ -101,7 +101,7 @@ public struct RESOLUTION: Decodable {
 ///     #EXT-X-STREAM-INF:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.2
-public struct EXT_X_STREAM_INF: Decodable {
+public struct EXT_X_STREAM_INF: Decodable, Sendable {
   /// The value is a decimal-integer of bits per second. This attribute is REQUIRED.
   public let bandwidth: Int
   /// The value is a decimal-integer of bits per second. This attribute is OPTIONAL.
@@ -129,7 +129,7 @@ public struct EXT_X_STREAM_INF: Decodable {
 ///     #EXT-X-I-FRAME-STREAM-INF:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.3
-public struct EXT_X_I_FRAME_STREAM_INF: Decodable {
+public struct EXT_X_I_FRAME_STREAM_INF: Decodable, Sendable {
   /// The value is a decimal-integer of bits per second. This attribute is REQUIRED.
   public let bandwidth: Int
   /// The value is a decimal-integer of bits per second. This attribute is OPTIONAL.
@@ -147,7 +147,7 @@ public struct EXT_X_I_FRAME_STREAM_INF: Decodable {
 }
 
 /// Specifies a Variant Stream by `#EXT-X-STREAM-INF` tag followed by a `<URI>`.
-public struct VariantStream: Decodable {
+public struct VariantStream: Decodable, Sendable {
   /// Specifies a Variant Stream, which is a set of Renditions that can be combined to play the presentation.
   public let ext_x_stream_inf: EXT_X_STREAM_INF
   /// Specifies a Media Playlist that carries a Rendition of the Variant Stream.

--- a/Sources/M3U8Decoder/MediaPlaylist.swift
+++ b/Sources/M3U8Decoder/MediaPlaylist.swift
@@ -31,7 +31,7 @@ import Foundation
 ///     #EXT-X-MAP:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.5
-public struct EXT_X_MAP: Decodable {
+public struct EXT_X_MAP: Decodable, Sendable {
   /// The value is a quoted-string containing a URI that identifies a resource that contains the Media Initialization Section. This attribute is REQUIRED.
   public let uri: String
   /// The value is a quoted-string specifying a byte range into the resource identified by the URI attribute. This attribute is OPTIONAL.
@@ -44,7 +44,7 @@ public struct EXT_X_MAP: Decodable {
 ///     #EXT_X_SESSION_KEY:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.4
-public struct EXT_X_KEY: Decodable {
+public struct EXT_X_KEY: Decodable, Sendable {
   /// The value is an enumerated-string that specifies the encryption method. This attribute is REQUIRED.
   public let method: String
   /// The value is a quoted-string that specifies how the key is represented in the resource identified by the URI. This attribute is OPTIONAL.
@@ -62,7 +62,7 @@ public struct EXT_X_KEY: Decodable {
 ///     #EXT-X-DATERANGE:<attribute-list>
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.7
-public struct EXT_X_DATERANGE: Decodable {
+public struct EXT_X_DATERANGE: Decodable, Sendable {
   /// A quoted-string that uniquely identifies a Date Range in the Playlist. This attribute is REQUIRED.
   public let id: String
   /// A client-defined quoted-string that specifies some set of attributes and their associated value semantics. This attribute is OPTIONAL.
@@ -90,7 +90,7 @@ public struct EXT_X_DATERANGE: Decodable {
 ///     #EXTINF:<duration>,[<title>]
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.1
-public struct EXTINF: Decodable {
+public struct EXTINF: Decodable, Sendable {
   /// Specifies the duration of the Media Segment in seconds. This attribute is REQUIRED.
   public let duration: Double
   /// Human-readable informative title of the Media Segment. This attribute is OPTIONAL.
@@ -102,7 +102,7 @@ public struct EXTINF: Decodable {
 ///     #EXT-X-BYTERANGE:<n>[@<o>]
 ///
 /// RFC: https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.2
-public struct EXT_X_BYTERANGE: Decodable {
+public struct EXT_X_BYTERANGE: Decodable, Sendable {
   /// n is a decimal-integer indicating the length of the sub-range in bytes. This attribute is REQUIRED.
   public let length: Int
   /// o is a decimal-integer indicating the start of the sub-range, as a byte offset from the beginning of the resource. This attribute is OPTIONAL.
@@ -110,7 +110,7 @@ public struct EXT_X_BYTERANGE: Decodable {
 }
 
 /// Specifies a Media Segment by a series of tags followed by a `<URI>`.
-public struct MediaSegment: Decodable {
+public struct MediaSegment: Decodable, Sendable {
   /// Specifies the duration of a Media Segment.
   public let extinf: EXTINF
   /// Indicates that a Media Segment is a sub-range of the resource identified by its URI.


### PR DESCRIPTION
This marks all the public playlist data structs as Sendable for clients to use.